### PR TITLE
Add taskhawk_task attribute which is used by Go library

### DIFF
--- a/modules/queue/main.tf
+++ b/modules/queue/main.tf
@@ -328,5 +328,8 @@ resource "google_cloud_scheduler_job" "job" {
   pubsub_target {
     topic_name = google_pubsub_topic.topic.id
     data       = base64encode(data.template_file.data[each.key].rendered)
+    attributes = {
+      taskhawk_task = each.value.task
+    }
   }
 }


### PR DESCRIPTION
- Python lib will use it as well to avoid double decoding