### PR TITLE
Add support for paused attribute

### DIFF
--- a/modules/queue/main.tf
+++ b/modules/queue/main.tf
@@ -330,6 +330,7 @@ resource "google_cloud_scheduler_job" "job" {
   schedule    = each.value.schedule
   time_zone   = each.value.timezone
   region      = var.scheduler_region
+  paused      = false
 
   pubsub_target {
     topic_name = google_pubsub_topic.topic.id
@@ -337,5 +338,9 @@ resource "google_cloud_scheduler_job" "job" {
     attributes = {
       taskhawk_task = each.value.task
     }
+  }
+
+  lifecycle {
+    ignore_changes = [paused]
   }
 }

--- a/modules/queue/versions.tf
+++ b/modules/queue/versions.tf
@@ -4,6 +4,6 @@ terraform {
   experiments = [module_variable_optional_attrs]
 
   required_providers {
-    google = ">= 3.16.0"
+    google = ">= 4.51.0"
   }
 }


### PR DESCRIPTION
- By default `paused` is set to `false` (same as upstream atttibute)
- Ignore life_cycle changes on the attribute
- Planned for version 4.0.0