### PR TITLE
Add support for enable_exactly_once_delivery on subscriptions

### DIFF
--- a/modules/queue/main.tf
+++ b/modules/queue/main.tf
@@ -42,6 +42,8 @@ resource "google_pubsub_subscription" "subscription" {
 
   labels = var.labels
 
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
+
   expiration_policy {
     ttl = ""
   }
@@ -147,6 +149,8 @@ resource "google_pubsub_subscription" "dlq_subscription" {
   ack_deadline_seconds = 20
 
   labels = var.labels
+
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
 
   expiration_policy {
     ttl = ""

--- a/variables.tf
+++ b/variables.tf
@@ -144,3 +144,8 @@ variable "scheduler_region" {
   description = "The region to use for Cloud Scheduler. This may be required if it's not set at the provider level."
   default     = ""
 }
+
+variable "enable_exactly_once_delivery" {
+  description = "Enable exactly-once delivery for the PubSub subscriptions"
+  default     = false
+}


### PR DESCRIPTION
Add enable_exactly_once_delivery as a configurable setting for pubsub subscriptions.