### PR TITLE
Add the exactly-once delivery setting to the submodule variables.tf

### DIFF
--- a/modules/queue/variables.tf
+++ b/modules/queue/variables.tf
@@ -114,3 +114,8 @@ variable "scheduler_region" {
   description = "The region to use for Cloud Scheduler. This may be required if it's not set at the provider level."
   default     = ""
 }
+
+variable "enable_exactly_once_delivery" {
+  description = "Enable exactly-once delivery for the PubSub subscriptions"
+  default     = false
+}


### PR DESCRIPTION
I missed that new variables need to be added to the submodule variables file as well.