### PR TITLE
Pass the exactly_once_delivery var to the submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "queue_default" {
 
   scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_default || job.priority == local.priority_empty || job.priority == null]
   scheduler_region = var.scheduler_region
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
 module "queue_high_priority" {
@@ -52,6 +53,7 @@ module "queue_high_priority" {
 
   scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_high]
   scheduler_region = var.scheduler_region
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
 module "queue_low_priority" {
@@ -80,6 +82,7 @@ module "queue_low_priority" {
 
   scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_low]
   scheduler_region = var.scheduler_region
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
 module "queue_bulk" {
@@ -108,4 +111,5 @@ module "queue_bulk" {
 
   scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_bulk]
   scheduler_region = var.scheduler_region
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,8 @@ module "queue_default" {
   dataflow_output_directory       = var.dataflow_output_directory
   dataflow_output_filename_prefix = var.dataflow_output_filename_prefix
 
-  scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_default || job.priority == local.priority_empty || job.priority == null]
-  scheduler_region = var.scheduler_region
+  scheduler_jobs               = [for job in var.scheduler_jobs : job if job.priority == local.priority_default || job.priority == local.priority_empty || job.priority == null]
+  scheduler_region             = var.scheduler_region
   enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
@@ -51,8 +51,8 @@ module "queue_high_priority" {
   dataflow_output_directory       = var.dataflow_output_directory
   dataflow_output_filename_prefix = var.dataflow_output_filename_prefix
 
-  scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_high]
-  scheduler_region = var.scheduler_region
+  scheduler_jobs               = [for job in var.scheduler_jobs : job if job.priority == local.priority_high]
+  scheduler_region             = var.scheduler_region
   enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
@@ -80,8 +80,8 @@ module "queue_low_priority" {
   dataflow_output_directory       = var.dataflow_output_directory
   dataflow_output_filename_prefix = var.dataflow_output_filename_prefix
 
-  scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_low]
-  scheduler_region = var.scheduler_region
+  scheduler_jobs               = [for job in var.scheduler_jobs : job if job.priority == local.priority_low]
+  scheduler_region             = var.scheduler_region
   enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }
 
@@ -109,7 +109,7 @@ module "queue_bulk" {
   dataflow_output_directory       = var.dataflow_output_directory
   dataflow_output_filename_prefix = var.dataflow_output_filename_prefix
 
-  scheduler_jobs   = [for job in var.scheduler_jobs : job if job.priority == local.priority_bulk]
-  scheduler_region = var.scheduler_region
+  scheduler_jobs               = [for job in var.scheduler_jobs : job if job.priority == local.priority_bulk]
+  scheduler_region             = var.scheduler_region
   enable_exactly_once_delivery = var.enable_exactly_once_delivery
 }


### PR DESCRIPTION
I temporary updated universal-appenv to point locally to this module this time to make sure other changes aren't required after this 😅 . This lets the change actually show up in a universal-appenv plan:
```
# module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_bulk.google_pubsub_subscription.dlq_subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "dlq_subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-bulk-dlq"
        name                         = "taskhawk-drbot-bulk-dlq"
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_bulk.google_pubsub_subscription.subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-bulk"
        name                         = "taskhawk-drbot-bulk"
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_default.google_pubsub_subscription.dlq_subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "dlq_subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-dlq"
        name                         = "taskhawk-drbot-dlq"
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_default.google_pubsub_subscription.subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot"
        name                         = "taskhawk-drbot"
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_high_priority.google_pubsub_subscription.dlq_subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "dlq_subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-high-priority-dlq"
        name                         = "taskhawk-drbot-high-priority-dlq"
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_high_priority.google_pubsub_subscription.subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-high-priority"
        name                         = "taskhawk-drbot-high-priority"
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_low_priority.google_pubsub_subscription.dlq_subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "dlq_subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-low-priority-dlq"
        name                         = "taskhawk-drbot-low-priority-dlq"
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.universal_dev_apps["drbot"].module.taskhawk[0].module.queue_low_priority.google_pubsub_subscription.subscription will be updated in-place
  ~ resource "google_pubsub_subscription" "subscription" {
      ~ enable_exactly_once_delivery = false -> true
        id                           = "projects/stcg-universal-dev-16/subscriptions/taskhawk-drbot-low-priority"
        name                         = "taskhawk-drbot-low-priority"
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```