### PR TITLE
Make the pubsub subscription's ack deadline configurable

### DIFF
--- a/modules/queue/main.tf
+++ b/modules/queue/main.tf
@@ -38,7 +38,7 @@ resource "google_pubsub_subscription" "subscription" {
   name  = "taskhawk-${var.queue}"
   topic = google_pubsub_topic.topic.name
 
-  ack_deadline_seconds = 20
+  ack_deadline_seconds = var.ack_deadline_seconds
 
   labels = var.labels
 
@@ -146,7 +146,7 @@ resource "google_pubsub_subscription" "dlq_subscription" {
   name  = "taskhawk-${var.queue}-dlq"
   topic = google_pubsub_topic.dlq_topic.name
 
-  ack_deadline_seconds = 20
+  ack_deadline_seconds = var.ack_deadline_seconds
 
   labels = var.labels
 

--- a/modules/queue/variables.tf
+++ b/modules/queue/variables.tf
@@ -122,5 +122,4 @@ variable "enable_exactly_once_delivery" {
 
 variable "ack_deadline_seconds" {
   description = "The ack deadline in seconds for the PubSub subscriptions"
-  default     = 20
 }

--- a/modules/queue/variables.tf
+++ b/modules/queue/variables.tf
@@ -119,3 +119,8 @@ variable "enable_exactly_once_delivery" {
   description = "Enable exactly-once delivery for the PubSub subscriptions"
   default     = false
 }
+
+variable "ack_deadline_seconds" {
+  description = "The ack deadline in seconds for the PubSub subscriptions"
+  default     = 20
+}

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,8 @@ variable "enable_exactly_once_delivery" {
   description = "Enable exactly-once delivery for the PubSub subscriptions"
   default     = false
 }
+
+variable "ack_deadline_seconds" {
+  description = "The ack deadline in seconds for the PubSub subscriptions"
+  default     = 20
+}


### PR DESCRIPTION
Make the pubsub subscription's ack deadline configurable. Will be used short term for drbot to help me rule out an ack delay with what i'm troubleshooting.